### PR TITLE
Change to use has_privilege and fix navbar

### DIFF
--- a/templates/mediagoblin/bits/navbar.html
+++ b/templates/mediagoblin/bits/navbar.html
@@ -87,7 +87,7 @@
               <a class="button" href="{{ request.urlgen('mediagoblin.submit.collection') }}">
                 {%- trans %}<i class="fa fa-folder-open"></i> Create new collection{% endtrans -%}
               </a>
-              {% if request.user.has_privilege('admin','moderator') %}
+              {% if request.user.has_privilege('admin') or request.user.has_privilege('moderator') %}
                 <p>
                   <span class="dropdown_title">Moderation powers:</span>
                   <a href="{{ request.urlgen('mediagoblin.moderation.media_panel') }}">

--- a/templates/mediagoblin/bits/navbar.html
+++ b/templates/mediagoblin/bits/navbar.html
@@ -55,7 +55,7 @@
           </div>
           <div class="clear"></div>
           {% if request.user and request.user.has_privilege('active') %}
-            <div class="header_dropdown">
+            <div id="header_dropdown">
               <p>
                 <span class="dropdown_title">
                   {% trans user_url=request.urlgen('mediagoblin.user_pages.user_home',

--- a/templates/mediagoblin/moderation/user.html
+++ b/templates/mediagoblin/moderation/user.html
@@ -177,7 +177,7 @@
         {% for privilege in privileges %}
           <tr>
             <td>{{ privilege.privilege_name }}</td>
-            {% if privilege in user.all_privileges  %}
+            {% if user.has_privilege(privilege.privilege_name) %}
               <td class="user_with_privilege">
                 {% trans %}Yes{% endtrans %}{% else %}
               <td class="user_without_privilege">
@@ -185,7 +185,7 @@
             </td>
             {% if request.user.has_privilege('admin') %}
               <td>
-                {% if privilege in user.all_privileges  %}
+                {% if user.has_privilege(privilege.privilege_name) %}
                 <input type=submit id="{{ privilege.privilege_name }}"
                        class="submit_button button"
                        value =" -" />


### PR DESCRIPTION
MediaGoblin will soon be changing User.has_privilege to only accept single arguments which require some template changes to the call. In some parts of the template too I have updated them to use User.has_privilege rather than doing the check itself. 

During testing I found a bug where the dropdown navbar was no longer functioning, this is because of a recent change where div was changed from using a class to using an id. I have fixed that too. 

Let me know if there are any problems.
