### PR TITLE
Use items() to support Python 3.

### DIFF
--- a/templates/mediagoblin/utils/exif.html
+++ b/templates/mediagoblin/utils/exif.html
@@ -32,7 +32,7 @@
     <h3><i class="fa fa-camera fa-fw"></i> Camera Information</h3>
     <table id="exif_camera_information">
       <tbody>
-      {% for label, value in media.exif_display_data_short().iteritems() %}
+      {% for label, value in media.exif_display_data_short().items() %}
       <tr>
         <td class="col1">{{ label }}</td>
         <td>{{ value }}</td>


### PR DESCRIPTION
Hi Jeremy, I'm just making this change in MediaGoblin core and figured I should update this theme too.